### PR TITLE
Vocative role

### DIFF
--- a/syntax-trees/nestle1904-lowfat/xml/boxwood.css
+++ b/syntax-trees/nestle1904-lowfat/xml/boxwood.css
@@ -1,0 +1,27 @@
+wg[class=cl] {
+  /* 
+    The nub of the spacing problem: 
+  
+    You really want spacing down to the last role before a word.
+    After that, you really don't want it.  Is there some way to
+    have it both ways with .css?
+  */
+  /*
+  position: relative;
+  display: block; 
+  */
+  padding-top: 0.25em;
+  padding-bottom: 0.25em;
+  padding-left: 1em;
+  display: block;
+
+  border-left: 1px inset grey;
+  border-top: 1px inset grey;
+  border-bottom: 1px inset grey; 
+}
+
+sentence>wg[class="cl"] {
+  border-left: none;
+  border-top: none;
+  border-bottom: none;   
+}

--- a/syntax-trees/nestle1904-lowfat/xml/treedown.css
+++ b/syntax-trees/nestle1904-lowfat/xml/treedown.css
@@ -1,5 +1,3 @@
-
-
 wg[class=header] {
     display: block;
     position: fixed;
@@ -63,19 +61,11 @@ wg[class=cl] {
     After that, you really don't want it.  Is there some way to
     have it both ways with .css?
   */
-  /*
-  position: relative;
-  display: block; 
-  */
+
   padding-top: 0.25em;
   padding-bottom: 0.25em;
   padding-left: 1em;
   display: block;
-
-/*
-  border-left: 1px inset grey;
-  border-top: 1px inset grey;
-  border-bottom: 1px inset grey; */
 }
 
 

--- a/syntax-trees/sblgnt-lowfat/xml/boxwood.css
+++ b/syntax-trees/sblgnt-lowfat/xml/boxwood.css
@@ -1,0 +1,27 @@
+wg[class=cl] {
+  /* 
+    The nub of the spacing problem: 
+  
+    You really want spacing down to the last role before a word.
+    After that, you really don't want it.  Is there some way to
+    have it both ways with .css?
+  */
+  /*
+  position: relative;
+  display: block; 
+  */
+  padding-top: 0.25em;
+  padding-bottom: 0.25em;
+  padding-left: 1em;
+  display: block;
+
+  border-left: 1px inset grey;
+  border-top: 1px inset grey;
+  border-bottom: 1px inset grey; 
+}
+
+sentence>wg[class="cl"] {
+  border-left: none;
+  border-top: none;
+  border-bottom: none;   
+}


### PR DESCRIPTION
Illustrates how to add the vocative role in a variety of cases.

Also separates boxwood cleanly from tree down to make it easier to turn
on and off.